### PR TITLE
Include CompilerExecute example in Program.Main

### DIFF
--- a/examples/AmplifierExamples/CompilerExecuteEx.cs
+++ b/examples/AmplifierExamples/CompilerExecuteEx.cs
@@ -16,7 +16,7 @@ namespace AmplifierExamples
             compiler1.UseDevice(0);
 
             var compiler2 = new OpenCLCompiler();
-            compiler1.UseDevice(1);
+            compiler2.UseDevice(1);
 
             compiler1.CompileKernel(typeof(NNActivationKernels));
             compiler2.CompileKernel(typeof(NNActivationKernels));

--- a/examples/AmplifierExamples/Program.cs
+++ b/examples/AmplifierExamples/Program.cs
@@ -15,25 +15,35 @@ namespace AmplifierExamples
             example.Execute();
             Console.WriteLine("\n---------------------Basic example---------------------------");
 
+            PrintThreeEmptyLines();
+
             Console.WriteLine("---------------------Array Loop example---------------------");
             example = new ArrayForLoopEx();
             example.Execute();
             Console.WriteLine("\n---------------------Array Loop example---------------------");
+
+            PrintThreeEmptyLines();
 
             Console.WriteLine("--------------------Simple kernel calls----------------------");
             example = new SimpleKernelCalls();
             example.Execute();
             Console.WriteLine("\n--------------------Simple kernel calls----------------------");
 
+            PrintThreeEmptyLines();
+
             Console.WriteLine("--------------------Save and load example-------------------");
             example = new SaveAndLoadEx();
             example.Execute();
             Console.WriteLine("\n--------------------Save and load example-------------------");
 
+            PrintThreeEmptyLines();
+
             Console.WriteLine("--------------------Compiler execute example-------------------");
             example = new CompilerExecuteEx();
             example.Execute();
             Console.WriteLine("\n--------------------Compiler execute example-------------------");
+
+            PrintThreeEmptyLines();
 
             Console.WriteLine("---------------------Complex math with struct example---------------------------");
             example = new WithStructEx();
@@ -41,6 +51,13 @@ namespace AmplifierExamples
             Console.WriteLine("\n---------------------Complex math with struct example---------------------------");
 
             Console.ReadLine();
+        }
+
+        private static void PrintThreeEmptyLines()
+        {
+            Console.WriteLine();
+            Console.WriteLine();
+            Console.WriteLine();
         }
     }
 }

--- a/examples/AmplifierExamples/Program.cs
+++ b/examples/AmplifierExamples/Program.cs
@@ -30,6 +30,10 @@ namespace AmplifierExamples
             example.Execute();
             Console.WriteLine("\n--------------------Save and load example-------------------");
 
+            Console.WriteLine("--------------------Compiler execute example-------------------");
+            example = new CompilerExecuteEx();
+            example.Execute();
+            Console.WriteLine("\n--------------------Compiler execute example-------------------");
 
             Console.WriteLine("---------------------Complex math with struct example---------------------------");
             example = new WithStructEx();


### PR DESCRIPTION
Hi Deepak,
First of all, Amplifier.NET is a great framework. So thank you for making it.

Ok, so while I was familiarising myself with the framework I noticed that one example was not outputting when run. So I have fixed this. 

I also included some additional empty lines between the output of each example. I feel this makes it easier to read (but yes I guess this is just personal preference, so I am happy to reverse it).

Please let me know. This is my first pull request on GitHub so I hope I haven't violated any conventions used here.  Trying my best :-) .

Kind Regards,
Doz